### PR TITLE
Implement basic form fill extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
-This is a [Plasmo extension](https://docs.plasmo.com/) project bootstrapped with [`plasmo init`](https://www.npmjs.com/package/plasmo).
+# Form Genie
 
-## Getting Started
+This repository contains a simple demo of automating form filling using a Plasmo
+based browser extension together with a Python FastAPI backend.  The backend
+leverages the `browser_use` library to read pages while the extension controls
+the user's active tab via Chrome's debugger API.
 
-First, run the development server:
+The extension attaches a debugger session to the active tab when its action button is clicked. It gathers the first form's field names, sends them to the backend and receives values to insert. After the fields are filled the form is submitted automatically.
+
+## Running the Backend
+
+Install the Python dependencies and start the API server:
 
 ```bash
-pnpm dev
-# or
+cd backend
+pip install -e .  # installs browser_use and FastAPI
+uvicorn main:app --reload
+```
+
+The server exposes a `/fillform` endpoint. It reads the target page with
+`browser_use` if field names are not supplied and returns simple demo values.
+
+## Developing the Extension
+
+```bash
+cd browser-use-extension
+npm install
 npm run dev
 ```
 
-Open your browser and load the appropriate development build. For example, if you are developing for the chrome browser, using manifest v3, use: `build/chrome-mv3-dev`.
+Load the build output from `build/chrome-mv3-dev` as an unpacked extension in Chrome.
 
-You can start editing the popup by modifying `popup.tsx`. It should auto-update as you make changes. To add an options page, simply add a `options.tsx` file to the root of the project, with a react component default exported. Likewise to add a content page, add a `content.ts` file to the root of the project, importing some module and do some logic, then reload the extension on your browser.
-
-For further guidance, [visit our Documentation](https://docs.plasmo.com/)
-
-## Making production build
-
-Run the following:
-
-```bash
-pnpm build
-# or
-npm run build
-```
-
-This should create a production bundle for your extension, ready to be zipped and published to the stores.
-
-## Submit to the webstores
-
-The easiest way to deploy your Plasmo extension is to use the built-in [bpp](https://bpp.browser.market) GitHub action. Prior to using this action however, make sure to build your extension and upload the first version to the store to establish the basic credentials. Then, simply follow [this setup instruction](https://docs.plasmo.com/framework/workflows/submit) and you should be on your way for automated submission!
+Click the extension icon on a page with a form to test the automatic fill behaviour.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,51 @@
-def main():
-    print("Hello from backend!")
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List, Dict, Optional
+import asyncio
 
+# browser_use is a small helper around Playwright used to inspect the target
+# page.  The library is only imported when needed so that the backend can start
+# even if the dependency is missing in development environments.
+
+
+app = FastAPI()
+
+class FillRequest(BaseModel):
+    url: str
+    fields: Optional[List[str]] = None
+
+class FillResponse(BaseModel):
+    fieldValues: Dict[str, str]
+
+@app.post("/fillform", response_model=FillResponse)
+def fill_form(req: FillRequest):
+    """Return values for the given form fields.
+
+    If the request does not provide field names, the backend uses the
+    ``browser_use`` library to fetch the page and read the first form's
+    input names.  This demonstrates using ``browser_use`` to read the page
+    while the extension itself uses Chrome's debugger to manipulate it.
+    """
+
+    async def _read_fields(url: str) -> List[str]:
+        from browser_use import Browser  # imported lazily
+
+        async with Browser() as b:
+            page = await b.page()
+            await page.goto(url)
+            return await page.evaluate(
+                "Array.from(document.forms[0]?.elements).map(e => e.name)"
+            )
+
+    fields = req.fields
+    if not fields:
+        # Run the asynchronous browser_use routine
+        fields = asyncio.run(_read_fields(req.url))
+
+    # simple demo: fill each field with its name reversed
+    field_values = {name: name[::-1] for name in fields}
+    return {"fieldValues": field_values}
 
 if __name__ == "__main__":
-    main()
+    import uvicorn
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/browser-use-extension/background.ts
+++ b/browser-use-extension/background.ts
@@ -1,0 +1,48 @@
+chrome.action.onClicked.addListener(async (tab) => {
+  if (!tab.id) return
+  const tabId = tab.id
+  try {
+    await chrome.debugger.attach({ tabId }, "1.3")
+    await chrome.debugger.sendCommand({ tabId }, "Runtime.enable")
+    await chrome.debugger.sendCommand({ tabId }, "DOM.enable")
+
+    const formFieldsResult = await chrome.debugger.sendCommand(
+      { tabId },
+      "Runtime.evaluate",
+      {
+        expression:
+          "JSON.stringify(Array.from(document.forms[0]?.elements).map(e => e.name))",
+        returnByValue: true
+      }
+    )
+    const fields = JSON.parse(formFieldsResult.result.value ?? "[]")
+    const response = await fetch("http://localhost:8000/fillform", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: tab.url, fields })
+    })
+    const data = await response.json()
+    if (data.fieldValues) {
+      for (const [name, value] of Object.entries(data.fieldValues)) {
+        await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
+          expression: `(() => {const el=document.querySelector('[name="${name}"]'); if(el){el.focus(); el.value=${JSON.stringify(
+            value
+          )}; el.dispatchEvent(new Event('input', {bubbles:true}));}})();`
+        })
+      }
+      await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
+        expression: `document.forms[0]?.submit();`
+      })
+    }
+  } catch (e) {
+    console.error("form fill error", e)
+  } finally {
+    try {
+      await chrome.debugger.detach({ tabId })
+    } catch {}
+  }
+})
+
+chrome.debugger.onDetach.addListener((_source, reason) => {
+  console.log("Debugger detached", reason)
+})

--- a/browser-use-extension/plasmo.config.ts
+++ b/browser-use-extension/plasmo.config.ts
@@ -1,11 +1,9 @@
 import type { PlasmoConfig } from "plasmo"
 
 export default <PlasmoConfig>{
-  contentScripts: ["contents/agent-box"],
-
   manifest: {
-    permissions: ["activeTab", "scripting"],
+    permissions: ["activeTab", "debugger"],
     host_permissions: ["http://localhost:8000/*"],
-    action: { default_title: "Hybrid Agent" }
+    action: { default_title: "Form Genie" }
   }
 }


### PR DESCRIPTION
## Summary
- add simple FastAPI backend that provides example field values
- include instructions for running backend and extension
- configure Plasmo manifest to use debugger permission
- implement background script to attach debugger, call backend and fill the form
- leverage browser_use in backend to read page when fields are absent
- log debugger detach events

## Testing
- `npm run build` *(fails: plasmo not found)*